### PR TITLE
Update Webpack, Fix wording in README intro.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ## Islandora Additions
 
-This is a fork of the demonstration project at https://github.com/ProjectMirador/mirador-integration. This project adapts the 
+This is a fork of the demonstration project at https://github.com/ProjectMirador/mirador-integration. This project adapts the
 code to work within [Drupal](https://drupal.org/) for the [Islandora](https://github.com/islandora/documentation) project.
 
-The main differences are 
+The main differences are
 
 1. Adding a few more plugins, and
 2. Invoking Mirador is done in the islandora_mirador Drupal module.
@@ -14,14 +14,16 @@ This repository is designed to show integrating Mirador 3 with modern frontend b
 
 ### Dependencies
 
-You will likely need to have at least the following dependencies available in your `package.json`.
+The dependencies are listed in package.json.
 
- - `mirador`
- - `react`
- - `react-dom`
- - `mirador-image-tools` - A plugin just to test plugin integration
+TO install them, run:
 
+```sh
+npm install
+``````
 ### Webpack
+
+Webpack is used to build the app for use by Islandora
 
 See `./webpack` for a basic webpack setup for Mirador 3 + a plugin.
 
@@ -29,10 +31,6 @@ See `./webpack` for a basic webpack setup for Mirador 3 + a plugin.
 npm run webpack
 ```
 
-### Parcel
+The output folder webpack/dist should now contain a file main.js which you can place in your drupal installation under [webroot]/libraries/mirador/dist.
 
-See `./parcel`, but essentially it is just an html file referencing the JavaScript.
-
-```sh
-npm run parcel
-```
+You can then go to /admin/config/media/mirador and set it to use the local version after clearing your site's cache.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Islandora Additions
 
 This is a fork of the demonstration project at https://github.com/ProjectMirador/mirador-integration. This project adapts the 
-code to work within [Drupal](https://drupal.org/) for the [Islandora](https://github.com/islandora/documentation).
+code to work within [Drupal](https://drupal.org/) for the [Islandora](https://github.com/islandora/documentation) project.
 
 The main differences are 
 

--- a/package.json
+++ b/package.json
@@ -12,14 +12,14 @@
   "license": "ISC",
   "dependencies": {
     "css-loader": "^3.6.0",
-    "mirador": "^3.0.0",
-    "mirador-image-tools": "^0.10.0",
-    "mirador-textoverlay": "^0.3.7",
     "parcel-bundler": "^1.12.4",
+    "mirador": "^3.0.0",
+    "mirador-image-tools": "^0.11.0",
+    "mirador-textoverlay": "^0.3.7",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "style-loader": "^1.2.1",
-    "webpack": "^4.43.0",
-    "webpack-cli": "^3.3.12"
+    "webpack": "^5.88.1",
+    "webpack-cli": "^5.1.4"
   }
 }


### PR DESCRIPTION
There is a problem compiling this app, Webpack, which is used to compile the app for distribution, uses an outdated encryption algorithm in version 4.x.

To fix this, I've updated the dependency to use Webpack and Webpack-CLI to 5.x. This does not break the build.

I've also updated the README to be more specific to this fork of the repo.

Once this is merged, you can create a new version of the app for distribution by following the README directions in the .gh_pages branch.